### PR TITLE
feat(aws): add awsv2 s3 client

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -46,7 +46,7 @@ add_library(dragonfly_lib channel_store.cc command_registry.cc
 
 find_library(ZSTD_LIB NAMES libzstd.a libzstdstatic.a zstd NAMES_PER_DIR REQUIRED)
 
-cxx_link(dragonfly_lib dfly_transaction dfly_facade redis_lib aws_lib strings_lib html_lib
+cxx_link(dragonfly_lib dfly_transaction dfly_facade redis_lib awsv2_lib strings_lib html_lib
          http_client_lib absl::random_random TRDP::jsoncons ${ZSTD_LIB} TRDP::lz4
          TRDP::croncpp)
 

--- a/src/server/detail/save_stages_controller.cc
+++ b/src/server/detail/save_stages_controller.cc
@@ -258,14 +258,6 @@ void SaveStagesController::UpdateSaveInfo() {
 }
 
 GenericError SaveStagesController::InitResources() {
-  if (is_cloud_ && !aws_) {
-    *aws_ = make_unique<cloud::AWS>("s3");
-    if (auto ec = aws_->get()->Init(); ec) {
-      aws_->reset();
-      return {ec, "Couldn't initialize AWS"};
-    }
-  }
-
   snapshots_.resize(use_dfs_format_ ? shard_set->size() + 1 : 1);
   for (auto& [snapshot, _] : snapshots_)
     snapshot = make_unique<RdbSnapshot>(fq_threadpool_, snapshot_storage_.get());

--- a/src/server/detail/save_stages_controller.h
+++ b/src/server/detail/save_stages_controller.h
@@ -10,7 +10,6 @@
 #include "server/detail/snapshot_storage.h"
 #include "server/rdb_save.h"
 #include "server/server_family.h"
-#include "util/cloud/aws.h"
 #include "util/fibers/fiberqueue_threadpool.h"
 
 namespace dfly {
@@ -29,7 +28,6 @@ struct SaveStagesInputs {
   util::fb2::FiberQueueThreadPool* fq_threadpool_;
   std::shared_ptr<LastSaveInfo>* last_save_info_;
   util::fb2::Mutex* save_mu_;
-  std::unique_ptr<util::cloud::AWS>* aws_;
   std::shared_ptr<SnapshotStorage> snapshot_storage_;
 };
 
@@ -118,8 +116,6 @@ struct SaveStagesController : public SaveStagesInputs {
 };
 
 GenericError ValidateFilename(const std::filesystem::path& filename, bool new_version);
-
-std::string InferLoadFile(string_view dir, util::cloud::AWS* aws);
 
 }  // namespace detail
 }  // namespace dfly

--- a/src/server/detail/snapshot_storage.cc
+++ b/src/server/detail/snapshot_storage.cc
@@ -5,13 +5,21 @@
 
 #include <absl/strings/str_replace.h>
 #include <absl/strings/strip.h>
+#include <aws/core/auth/AWSCredentialsProvider.h>
+#include <aws/s3/S3Client.h>
+#include <aws/s3/model/ListObjectsV2Request.h>
+#include <aws/s3/model/PutObjectRequest.h>
 
 #include <regex>
 
 #include "base/logging.h"
 #include "io/file_util.h"
 #include "server/engine_shard_set.h"
-#include "util/cloud/s3.h"
+#include "util/aws/aws.h"
+#include "util/aws/credentials_provider_chain.h"
+#include "util/aws/s3_endpoint_provider.h"
+#include "util/aws/s3_read_file.h"
+#include "util/aws/s3_write_file.h"
 #include "util/fibers/fiber_file.h"
 
 namespace dfly {
@@ -166,30 +174,37 @@ io::Result<std::vector<std::string>, GenericError> FileSnapshotStorage::LoadPath
   return paths;
 }
 
-AwsS3SnapshotStorage::AwsS3SnapshotStorage(util::cloud::AWS* aws) : aws_{aws} {
+AwsS3SnapshotStorage::AwsS3SnapshotStorage(const std::string& endpoint) {
+  shard_set->pool()->GetNextProactor()->Await([&] {
+    // S3ClientConfiguration may request configuration and credentials from
+    // EC2 metadata so must be run in a proactor thread.
+    Aws::S3::S3ClientConfiguration s3_conf{};
+    std::shared_ptr<Aws::Auth::AWSCredentialsProvider> credentials_provider =
+        std::make_shared<util::aws::CredentialsProviderChain>();
+    // Pass a custom endpoint. If empty uses the S3 endpoint.
+    std::shared_ptr<Aws::S3::S3EndpointProviderBase> endpoint_provider =
+        std::make_shared<util::aws::S3EndpointProvider>(endpoint);
+    s3_ = std::make_shared<Aws::S3::S3Client>(credentials_provider, endpoint_provider, s3_conf);
+  });
 }
 
 io::Result<std::pair<io::Sink*, uint8_t>, GenericError> AwsS3SnapshotStorage::OpenWriteFile(
     const std::string& path) {
-  DCHECK(aws_);
+  util::fb2::ProactorBase* proactor = shard_set->pool()->GetNextProactor();
+  return proactor->Await([&]() -> io::Result<std::pair<io::Sink*, uint8_t>, GenericError> {
+    std::optional<std::pair<std::string, std::string>> bucket_path = GetBucketPath(path);
+    if (!bucket_path) {
+      return nonstd::make_unexpected(GenericError("Invalid S3 path"));
+    }
+    auto [bucket, key] = *bucket_path;
+    io::Result<util::aws::S3WriteFile> file = util::aws::S3WriteFile::Open(bucket, key, s3_);
+    if (!file) {
+      return nonstd::make_unexpected(GenericError(file.error(), "Failed to open write file"));
+    }
 
-  std::optional<std::pair<std::string, std::string>> bucket_path = GetBucketPath(path);
-  if (!bucket_path) {
-    return nonstd::make_unexpected(GenericError("Invalid S3 path"));
-  }
-  auto [bucket_name, obj_path] = *bucket_path;
-
-  util::cloud::S3Bucket bucket(*aws_, bucket_name);
-  std::error_code ec = bucket.Connect(kBucketConnectMs);
-  if (ec) {
-    return nonstd::make_unexpected(GenericError(ec, "Couldn't connect to S3 bucket"));
-  }
-  auto res = bucket.OpenWriteFile(obj_path);
-  if (!res) {
-    return nonstd::make_unexpected(GenericError(res.error(), "Couldn't open file for writing"));
-  }
-
-  return std::pair<io::Sink*, uint8_t>(*res, FileType::CLOUD);
+    util::aws::S3WriteFile* f = new util::aws::S3WriteFile(std::move(*file));
+    return std::pair<io::Sink*, uint8_t>(f, FileType::CLOUD);
+  });
 }
 
 io::ReadonlyFileOrError AwsS3SnapshotStorage::OpenReadFile(const std::string& path) {
@@ -197,18 +212,8 @@ io::ReadonlyFileOrError AwsS3SnapshotStorage::OpenReadFile(const std::string& pa
   if (!bucket_path) {
     return nonstd::make_unexpected(GenericError("Invalid S3 path"));
   }
-  auto [bucket_name, obj_path] = *bucket_path;
-
-  util::cloud::S3Bucket bucket{*aws_, bucket_name};
-  std::error_code ec = bucket.Connect(kBucketConnectMs);
-  if (ec) {
-    return nonstd::make_unexpected(GenericError(ec, "Couldn't connect to S3 bucket"));
-  }
-  auto res = bucket.OpenReadFile(obj_path);
-  if (!res) {
-    return nonstd::make_unexpected(GenericError(res.error(), "Couldn't open file for reading"));
-  }
-  return res;
+  auto [bucket, key] = *bucket_path;
+  return new util::aws::S3ReadFile(bucket, key, s3_);
 }
 
 io::Result<std::string, GenericError> AwsS3SnapshotStorage::LoadPath(std::string_view dir,
@@ -312,19 +317,29 @@ io::Result<std::vector<std::string>, GenericError> AwsS3SnapshotStorage::LoadPat
 
 io::Result<std::vector<std::string>, GenericError> AwsS3SnapshotStorage::ListObjects(
     std::string_view bucket_name, std::string_view prefix) {
-  util::cloud::S3Bucket bucket(*aws_, bucket_name);
-  std::error_code ec = bucket.Connect(kBucketConnectMs);
-  if (ec) {
-    return nonstd::make_unexpected(GenericError{ec, "Couldn't connect to S3 bucket"});
-  }
-
+  // Each list objects request has a 1000 object limit, so page through the
+  // objects if needed.
+  std::string continuation_token;
   std::vector<std::string> keys;
-  ec = bucket.ListAllObjects(
-      prefix, [&](size_t sz, std::string_view name) { keys.push_back(std::string(name)); });
-  if (ec) {
-    return nonstd::make_unexpected(GenericError{ec, "Couldn't list objects in S3 bucket"});
-  }
+  do {
+    Aws::S3::Model::ListObjectsV2Request request;
+    request.SetBucket(std::string(bucket_name));
+    request.SetPrefix(std::string(prefix));
+    if (continuation_token != "") {
+      request.SetContinuationToken(continuation_token);
+    }
 
+    Aws::S3::Model::ListObjectsV2Outcome outcome = s3_->ListObjectsV2(request);
+    if (outcome.IsSuccess()) {
+      continuation_token = outcome.GetResult().GetNextContinuationToken();
+      for (const auto& object : outcome.GetResult().GetContents()) {
+        keys.push_back(object.GetKey());
+      }
+    } else {
+      return nonstd::make_unexpected(GenericError{"Failed list objects in S3 bucket: " +
+                                                  outcome.GetError().GetExceptionName()});
+    }
+  } while (continuation_token != "");
   return keys;
 }
 

--- a/src/server/detail/snapshot_storage.h
+++ b/src/server/detail/snapshot_storage.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <aws/s3/S3Client.h>
+
 #include <filesystem>
 #include <string>
 #include <string_view>
@@ -10,7 +12,6 @@
 
 #include "io/io.h"
 #include "server/common.h"
-#include "util/cloud/aws.h"
 #include "util/fibers/fiberqueue_threadpool.h"
 #include "util/fibers/uring_file.h"
 
@@ -71,7 +72,7 @@ class FileSnapshotStorage : public SnapshotStorage {
 
 class AwsS3SnapshotStorage : public SnapshotStorage {
  public:
-  AwsS3SnapshotStorage(util::cloud::AWS* aws);
+  AwsS3SnapshotStorage(const std::string& endpoint);
 
   io::Result<std::pair<io::Sink*, uint8_t>, GenericError> OpenWriteFile(
       const std::string& path) override;
@@ -90,7 +91,7 @@ class AwsS3SnapshotStorage : public SnapshotStorage {
   io::Result<std::vector<std::string>, GenericError> ListObjects(std::string_view bucket_name,
                                                                  std::string_view prefix);
 
-  util::cloud::AWS* aws_;
+  std::shared_ptr<Aws::S3::S3Client> s3_;
 };
 
 // Returns bucket_name, obj_path for an s3 path.

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -51,8 +51,7 @@ extern "C" {
 #include "server/version.h"
 #include "strings/human_readable.h"
 #include "util/accept_server.h"
-#include "util/cloud/aws.h"
-#include "util/cloud/s3.h"
+#include "util/aws/aws.h"
 #include "util/fibers/fiber_file.h"
 
 using namespace std;
@@ -89,6 +88,8 @@ ABSL_FLAG(ReplicaOfFlag, replicaof, ReplicaOfFlag{},
           "Specifies a host and port which point to a target master "
           "to replicate. "
           "Format should be <IPv4>:<PORT> or host:<PORT> or [<IPv6>]:<PORT>");
+
+ABSL_FLAG(string, s3_endpoint, "", "endpoint for s3 snapshots, default uses aws regional endpoint");
 
 ABSL_DECLARE_FLAG(int32_t, port);
 ABSL_DECLARE_FLAG(bool, cache_mode);
@@ -419,12 +420,9 @@ void ServerFamily::Init(util::AcceptServer* acceptor, std::vector<facade::Listen
 
   string flag_dir = GetFlag(FLAGS_dir);
   if (IsCloudPath(flag_dir)) {
-    aws_ = make_unique<cloud::AWS>("s3");
-    auto ec = shard_set->pool()->GetNextProactor()->Await([&] { return aws_->Init(); });
-    if (ec) {
-      LOG(FATAL) << "Failed to initialize AWS " << ec;
-    }
-    snapshot_storage_ = std::make_shared<detail::AwsS3SnapshotStorage>(aws_.get());
+    shard_set->pool()->GetNextProactor()->Await([&] { util::aws::Init(); });
+    snapshot_storage_ =
+        std::make_shared<detail::AwsS3SnapshotStorage>(absl::GetFlag(FLAGS_s3_endpoint));
   } else if (fq_threadpool_) {
     snapshot_storage_ = std::make_shared<detail::FileSnapshotStorage>(fq_threadpool_.get());
   } else {
@@ -895,9 +893,9 @@ GenericError ServerFamily::DoSave() {
 }
 
 GenericError ServerFamily::DoSave(bool new_version, string_view basename, Transaction* trans) {
-  SaveStagesController sc{detail::SaveStagesInputs{
-      new_version, basename, trans, &service_, &is_saving_, fq_threadpool_.get(), &last_save_info_,
-      &save_mu_, &aws_, snapshot_storage_}};
+  SaveStagesController sc{detail::SaveStagesInputs{new_version, basename, trans, &service_,
+                                                   &is_saving_, fq_threadpool_.get(),
+                                                   &last_save_info_, &save_mu_, snapshot_storage_}};
   return sc.Save();
 }
 

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -15,13 +15,10 @@
 #include "server/replica.h"
 
 namespace util {
+
 class AcceptServer;
 class ListenerInterface;
 class HttpListenerBase;
-
-namespace cloud {
-class AWS;
-}  // namespace cloud
 
 }  // namespace util
 
@@ -250,7 +247,6 @@ class ServerFamily {
 
   Done schedule_done_;
   std::unique_ptr<FiberQueueThreadPool> fq_threadpool_;
-  std::unique_ptr<util::cloud::AWS> aws_;
   std::shared_ptr<detail::SnapshotStorage> snapshot_storage_;
 };
 


### PR DESCRIPTION
Integrates `awsv2` (which uses the AWS SDK) into Dragonfly for S3 cloud snapshots (see https://github.com/romange/helio/pull/146).

`ServerFamily` will initialise the AWS SDK on startup (if configured to use S3), which loads configuration and credentials.

Each proactor shares the same S3 client to avoid loading credentials per proactor. The underlying HTTP client is thread safe and non-blocking, and the rest of the S3 client is thread safe so sharing the S3 client across proactors is ok (its mostly stateless so there won't be any contention except a RW lock to get credentials).

# Testing
## 200GB snapshot :heavy_check_mark:
Provision a `r6g.8xlarge` and fill with 200GB of random data (~6GB per shard) (`redis-cli debug populate 200000000 test 1000 rand`), then keep uploading/downloading snapshots for a few hours with `for i in $(seq 100); do redis-cli save df snapshot; redis-cli debug load {bucket}/snapshots/snapshot-summary.dfs; done`.

(Note use a fixed snapshot name to avoid paying high S3 storage costs. S3 should be in the same region to avoid paying for the network upload)

Benchmarks:
* 200GB save: 20-30% CPU, 3:50 minutes
  * Note saving a snapshot to disk then uploading was 7 minutes so this is an improvement
* 200GB load: 20-25% CPU, 4:30 minutes

As described in https://github.com/romange/helio/pull/146, we could improve performance by removing the MD5 content header and payload signature, though its a tradeoff of performance and security, and depends on the SOC2 requirements.

## Schedule
Setup a log running test with ~10GB and just leave to keep taking snapshots and re-loading for a week. This should test any edge cases from S3 and verify we correctly renew expired credentials from EC2 metadata, and check for memory leaks etc.

(~10GB should be ok given we want to run this for a long time so an `r6g.16xlarge` would be too expensive).

## Retries :heavy_check_mark: 
To test the client correctly reconnects, running the upload/download loop shows above via a proxy (such as [toxiproxy](https://github.com/Shopify/toxiproxy)), then breaking the networking to check the client retries and recovers.

Configuring the proxy to drop the network for 1 second every 10 seconds, meaning existing connections are closed and reconnects fail to connect in that one second. Running with a 10GB snapshot which takes ~30s to load and ~30s to save, meaning each upload/download reconnects ~3 times.

Repeating 100 times works ok. Seeing the SDK correctly backoff and retry:
```
W20230925 08:59:45.336876 1018123 http_client.cc:203] aws: http client: failed to connect; host=localhost; error=system:111
W20230925 08:59:45.336966 1018123 logger.cc:79] aws: AWSClient: Request failed, now waiting 800 ms before attempting again.
```

The above 200GB snapshot test also showed occasional 5xx errors from S3 that are retried correctly:
```
W20230925 11:01:51.256095 20199 logger.cc:78] aws: AWSErrorMarshaller: Encountered AWSError 'InternalError': We encountered an internal error. Please try again.
W20230925 11:01:51.256206 20199 logger.cc:81] aws: AWSXmlClient: HTTP response code: 500
W20230925 11:01:51.256295 20199 logger.cc:78] aws: AWSClient: Request failed, now waiting 0 ms before attempting again.
```

## Credentials :heavy_check_mark: 
Test the different credential types
  - [x] Environment variables
  - [x] Local profile
    - [x] Override profile with `AWS_PROFILE`
  - [x] EC2 metadata

## Error Handling :heavy_check_mark: 
- [x] Invalid credentials: Logs `aws: s3 write file: failed to create multipart upload: InvalidAccessKeyId` and `SAVE` returns `Failed to open write file` (The error is not retryable so the SDK won't retry)
- [x] Bucket not found: Logs `aws: s3 write file: failed to create multipart upload: NoSuchBucket` and `SAVE` returns `Failed to open write file` (The error is not retryable so the SDK won't retry)
- [x] S3 unreachable: If S3 is unreachable (eg a firewall blocking access), the SDK will retry 5 times, which takes ~30s (with backoff) before it fails and logs a `Failed to open write file` as above

## Non-Blocking :heavy_check_mark:
To verify uploads don't block the thread, we can run a `redis-cli save` loop, and also run a lightweight benchmark measuring the maximum latency. We should not see the maximum latency increase significantly (which would indicate a thread may be blocked).

Running a `PING` loop and `GET foo` loop, then measuring the latency when running the 200GB upload loop above, seeing latency consistently under 10ms. There is overhead to uploading snapshots though there doesn't seem to be any threads being blocked for a long time.

## Regression Tests
Add regression tests for S3 cloud snapshots.

(Theres an open ticket for this so may add in a separate PR)

# Tasks
- [x] Support buckets with 1000+ objects